### PR TITLE
Fix several problems in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-xdg=${${XDG_DATA_HOME}:-${HOME}/.local/share}
-DIRECTORY="${xdg}/rofi/themes/}"
+xdg="${XDG_DATA_HOME:-${HOME}/.local/share}"
+DIRECTORY="${xdg}/rofi/themes"
 
 if [ ! -d "${DIRECTORY}" ]
 then
@@ -10,26 +10,26 @@ then
 fi
 
 declare -i ia=0
-for themefile in **/*.rasi 
+for themefile in **/*.rasi
 do
-    if [ -f "${themefile}" ] && [ ${ia} -eq 0 ]
+    if [ -f "${DIRECTORY}/${themefile##*/}" ] && [ ${ia} -eq 0 ]
     then
-        echo "Theme '${themefile}' exists, overwrite? y/N/a(ll)"
+        echo -n "Theme '${DIRECTORY}/${themefile##*/}' exists, overwrite? y/N/a(ll) "
         read answer
-        if [ x$answer = x"y" ]
+        if [ "x$answer" = x"y" ]
         then
             echo "+Installing '${themefile}'"
-            install "${themefile}" "${DIRECTORY}"
-        elif [ x${answer} = x"a" ]
+            install -m 644 "${themefile}" "${DIRECTORY}"
+        elif [ "x${answer}" = x"a" ]
         then
             ia=1
             echo "+Installing '${themefile}'"
-            install "${themefile}" "${DIRECTORY}"
+            install -m 644 "${themefile}" "${DIRECTORY}"
         else
             echo "+Skipping ${themefile}"
-        fi 
+        fi
     else
-            echo "+Installing '${themefile}'"
-            install "${themefile}" "${DIRECTORY}"
+        echo "+Installing '${themefile}'"
+        install -m 644 "${themefile}" "${DIRECTORY}"
     fi
 done


### PR DESCRIPTION
* Fix shell syntax in 'xdg' and 'DIRECTORY' variable definitions.
* Fix check whether theme file already exists to look at destination not source file.
* Quote 'answer' shell variable.
* Install themes with proper file permissions.
* Make indentation consistent.
