### PR TITLE
Change 'sidebar' to 'mode-switcher' in user themes.

### DIFF
--- a/User Themes/arc-red-dark.rasi
+++ b/User Themes/arc-red-dark.rasi
@@ -97,7 +97,7 @@
     background-color: @alternate-active-background;
     text-color:       @alternate-active-foreground;
 }
-#sidebar {
+#mode-switcher {
     border:       2px 0px 0px ;
     border-color: @separatorcolor;
 }

--- a/User Themes/flat-orange.rasi
+++ b/User Themes/flat-orange.rasi
@@ -110,7 +110,7 @@ scrollbar {
    handle-width: 15px;
 }
 
-sidebar {
+mode-switcher {
    background-color: @blackwidget;
 }
 

--- a/User Themes/flat-orange.rasi
+++ b/User Themes/flat-orange.rasi
@@ -31,7 +31,7 @@ window {
 mainbox {
    background-color: @blackdarkest;
    spacing:0px;
-   children: [inputbar, message, sidebar, listview];
+   children: [inputbar, message, mode-switcher, listview];
 }
 
 message {

--- a/User Themes/material.rasi
+++ b/User Themes/material.rasi
@@ -40,7 +40,7 @@ window {
 }
 
 mainbox {
-	children: [inputbar, message, sidebar, listview];
+	children: [inputbar, message, mode-switcher, listview];
 	spacing: 30px;
 	/*margin: 20%;*/
 	padding: 30px 0;
@@ -72,7 +72,7 @@ case-indicator {
 	text-color: @base0F;
 }
 
-sidebar, message {
+mode-switcher, message {
 	border: 1px 0;
 	border-color: @base0D;
 }

--- a/User Themes/oxide.rasi
+++ b/User Themes/oxide.rasi
@@ -105,7 +105,7 @@ scrollbar {
     handle-width: 8px;
     padding:      0;
 }
-sidebar {
+mode-switcher {
     border:       2px dash 0px 0px;
     border-color: @separatorcolor;
 }

--- a/User Themes/rezlooks.rasi
+++ b/User Themes/rezlooks.rasi
@@ -54,7 +54,7 @@
 }
 
 #tabcontent {
-    children: [ topborder, sidebar, mainbox ];
+    children: [ topborder, mode-switcher, mainbox ];
     background-color: transparent;
     spacing: 0;
     border: 8px;
@@ -162,7 +162,7 @@
     handle-width: 8px ;
     padding:      0;
 }
-#sidebar {
+#mode-switcher {
     border:       0px 0px 0px 1px;
     border-color: @dark-border-color;
     spacing: 0px;

--- a/User Themes/sidetab.rasi
+++ b/User Themes/sidetab.rasi
@@ -53,7 +53,7 @@ window {
 
 mainbox {
 	spacing:  0.8em;
-	children: [ entry,listview,sidebar ];
+	children: [ entry,listview,mode-switcher ];
 }
 
 button { padding: 5px 2px; }

--- a/User Themes/solarized-darker.rasi
+++ b/User Themes/solarized-darker.rasi
@@ -130,7 +130,7 @@ scrollbar {
     handle-width: 8px ;
     padding:      0;
 }
-sidebar {
+mode-switcher {
     border:       2px dash 0px 0px ;
     border-color: @separatorcolor;
 }


### PR DESCRIPTION
According to https://github.com/davatorium/rofi/releases/tag/1.5.3, 'sidebar' was renamed to 'mode-switcher'.

This fixes how user themes look in Rofi 1.5.3.